### PR TITLE
fix: 使用系统随机源生成自动 seed

### DIFF
--- a/template_manager.py
+++ b/template_manager.py
@@ -8,7 +8,7 @@ import copy
 import hashlib
 import json
 import logging
-import random
+import secrets
 import re
 import time
 from urllib.parse import quote, unquote, urlencode, urlparse
@@ -1757,7 +1757,7 @@ async def execute_template(
     outputs = template.get("outputs", {})
     params = {
         **{
-            input_name: random.randint(0, _MAX_COMFY_SEED)
+            input_name: secrets.randbelow(_MAX_COMFY_SEED + 1)
             for input_name in inputs
             if input_name == _SEED_INPUT_NAME
         },


### PR DESCRIPTION
## PR 标题

`fix: 使用系统随机源生成自动 seed`

## 概述

将自动生成 ComfyUI 模板 seed 的实现从模块级 `random.randint()` 改为 `secrets.randbelow()`。

## 问题

模板可以在 App Mode 中暴露一个名为 `seed` 的输入。当 MCP 调用方没有主动传入 seed 时，`execute_template()` 当前会通过模块级的 `random` 伪随机数生成器生成 seed：

```python
random.randint(0, _MAX_COMFY_SEED)
```

在连续通过 MCP 执行同一个模板时，我实际遇到了一个问题：即使传入的 MCP 参数中完全没有 `seed`，插件仍然可能再次生成一个之前已经出现过的 seed。

当其他执行参数也完全相同时，ComfyUI 会认为执行图没有变化，从而直接命中缓存，导致后续任务几乎瞬间完成，并返回与之前完全相同的图片，而不是重新进行采样。

Python 的 `random` 模块使用的是共享的、带内部状态的伪随机数生成器。对于这里“每次执行都希望获得一个新的随机 seed”的用途，并不需要依赖可复现的模块级 PRNG 状态。

## 修复方式

改为使用 Python 标准库 `secrets` 提供的系统随机源生成自动 seed：

```python
secrets.randbelow(_MAX_COMFY_SEED + 1)
```

这样仍然保持与原逻辑完全相同的 seed 范围：

```text
0 <= seed <= _MAX_COMFY_SEED
```

因为 `secrets.randbelow(n)` 返回的范围为 `[0, n)`。

这个修改不会影响调用方显式传入 seed 的行为。现有参数合并顺序保持不变，因此如果调用方主动传入 `seed`，仍然会覆盖自动生成的值。

同时，这个修改不会增加任何第三方依赖，因为 `secrets` 属于 Python 标准库。

## 复现方式

1. 在 App Mode 中创建或刷新一个包含 `seed` 输入的模板。
2. 通过 MCP 连续调用该模板，并且不要在参数中传入 `seed`。
3. 记录每次调用时传入的参数以及插件内部生成的 seed。
4. 在出现问题的环境中，可以观察到某次执行重新生成了之前已经出现过的 seed，即使调用方没有传入 seed。
5. 当其他参数也保持一致时，ComfyUI 可能因此直接复用之前的缓存结果，而不是重新采样。

## 验证

* 确认自动生成的 seed 始终位于 `0.._MAX_COMFY_SEED` 范围内。
* 确认调用方显式传入的 seed 仍然可以覆盖自动生成的 seed。
* 连续多次通过 MCP 执行同一个模板且不传入 seed，确认每次执行都从系统随机源获得新的随机值。
* 运行：

```bash
python -m compileall .
```

确认代码可以正常编译。

## 修改范围

这是一个刻意保持最小范围的修复，只修改现有自动 `seed` 功能所使用的随机数来源，不改变其他模板执行逻辑。
